### PR TITLE
apollo-server-fastify's context function now receives reply object.

### DIFF
--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -8,7 +8,7 @@ import {
   processFileUploads,
 } from 'apollo-server-core';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { IncomingMessage, ServerResponse, Server } from 'http';
+import { IncomingMessage, OutgoingMessage, ServerResponse, Server } from 'http';
 import { graphqlFastify } from './fastifyApollo';
 import { GraphQLOperation } from 'graphql-upload';
 
@@ -170,11 +170,17 @@ export class ApolloServer extends ApolloServerBase {
             beforeHandlers.push(fileUploadMiddleware(this.uploadsConfig, this));
           }
 
+          const graphQLServerOptions = this.graphQLServerOptions.bind(this);
+          const applyContextArgs = async (
+            request?: FastifyRequest<IncomingMessage>,
+            reply?: FastifyReply<OutgoingMessage>,
+          ) => graphQLServerOptions({ request, reply });
+
           instance.route({
             method: ['GET', 'POST'],
             url: '/',
             beforeHandler: beforeHandlers,
-            handler: await graphqlFastify(this.graphQLServerOptions.bind(this)),
+            handler: await graphqlFastify(applyContextArgs),
           });
         },
         {

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -1,7 +1,7 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import fastify from 'fastify';
 
-import http from 'http';
+import http, { IncomingMessage, OutgoingMessage } from 'http';
 
 import request from 'request';
 import FormData from 'form-data';
@@ -56,13 +56,24 @@ describe('apollo-server-fastify', () => {
   let server: ApolloServer;
   let app: FastifyInstance;
   let httpServer: http.Server;
+  let replyDecorator: jest.Mock | undefined;
+  let requestDecorator: jest.Mock | undefined;
 
   async function createServer(
     serverOptions: Config,
     options: Partial<ServerRegistration> = {},
+    mockDecorators: boolean = false,
   ) {
     server = new ApolloServer(serverOptions);
     app = fastify();
+
+    if (mockDecorators) {
+      replyDecorator = jest.fn();
+      requestDecorator = jest.fn();
+
+      app.decorateReply('replyDecorator', replyDecorator);
+      app.decorateRequest('requestDecorator', requestDecorator);
+    }
 
     app.register(server.createHandler(options));
     await app.listen(port);
@@ -79,6 +90,35 @@ describe('apollo-server-fastify', () => {
   describe('constructor', () => {
     it('accepts typeDefs and resolvers', () => {
       return createServer({ typeDefs, resolvers });
+    });
+  });
+
+  describe('applyContextArgs', () => {
+    it('provides FastifyRequest and FastifyReply to ContextFunction', async () => {
+      interface ContextArgs {
+        request: FastifyRequest<IncomingMessage> & {
+          requestDecorator: () => any;
+        };
+        reply: FastifyReply<OutgoingMessage> & { replyDecorator: () => any };
+      }
+
+      const context = ({ request, reply }: ContextArgs) => {
+        request!.requestDecorator();
+        reply!.replyDecorator();
+        return {};
+      };
+
+      const { url: uri } = await createServer(
+        { typeDefs, resolvers, context },
+        {},
+        true,
+      );
+
+      const apolloFetch = createApolloFetch({ uri });
+      await apolloFetch({ query: '{hello}' });
+
+      expect(requestDecorator!.mock.calls.length).toEqual(1);
+      expect(replyDecorator!.mock.calls.length).toEqual(1);
     });
   });
 


### PR DESCRIPTION
### Problem
The context function in `apollo-server-fastify` is not receiving the `reply` object. This is due to the `request` and `reply` being spread into `graphqlServerOptions`(in [resolveGraphqlOptions](https://github.com/apollographql/apollo-server/blob/01519bdb471e2684cfccbf275d88a8435c2bf50a/packages/apollo-server-core/src/graphqlOptions.ts#L91) via [runHttpQuery](https://github.com/apollographql/apollo-server/blob/01519bdb471e2684cfccbf275d88a8435c2bf50a/packages/apollo-server-core/src/runHttpQuery.ts#L124)) - but `graphqlServerOptions` is expecting an object ([here](https://github.com/apollographql/apollo-server/blob/945dd297feb818b90d7bde3f77759061a2ce2135/packages/apollo-server-core/src/ApolloServer.ts#L752)).

#### Related Issues
- https://github.com/apollographql/apollo-server/issues/3156

### Solution
Add `applyContextArgs` function which receives the `reply` and `request` being spread in, and places them into an object which is then passed into `graphqlServerOptions`.
 
### Test plan
Confirm unit tests pass:
```
$ cd packages/apollo-server-fastify && jest
```